### PR TITLE
add a state of idle to improve setting operation

### DIFF
--- a/custom_components/rinnaicontrolr-ha/device.py
+++ b/custom_components/rinnaicontrolr-ha/device.py
@@ -114,6 +114,10 @@ class RinnaiDeviceDataUpdateCoordinator(DataUpdateCoordinator):
 		return strtobool(str(self._device_information["data"]["getDevice"]["info"]["domestic_combustion"]))
 
 	@property
+	def is_on(self) -> bool:
+		return self._device_information["data"]["getDevice"]["shadow"]["set_operation_enabled"]
+
+	@property
 	def is_recirculating(self) -> bool:
 		return strtobool(str(self._device_information["data"]["getDevice"]["shadow"]["recirculation_enabled"]))
 

--- a/custom_components/rinnaicontrolr-ha/manifest.json
+++ b/custom_components/rinnaicontrolr-ha/manifest.json
@@ -5,6 +5,6 @@
     "documentation": "https://github.com/explosivo22/rinnaicontrolr-ha/",
     "codeowners": [ "@explosivo22" ],
     "requirements": [ "aiorinnai==0.3.1" ],
-    "version": "1.3.5",
+    "version": "1.3.6",
     "iot_class":  "cloud_polling"
 }

--- a/custom_components/rinnaicontrolr-ha/water_heater.py
+++ b/custom_components/rinnaicontrolr-ha/water_heater.py
@@ -14,7 +14,9 @@ from .const import DOMAIN as RINNAI_DOMAIN, LOGGER, CONF_UNIT
 from .device import RinnaiDeviceDataUpdateCoordinator
 from .entity import RinnaiEntity
 
-OPERATION_LIST = [STATE_OFF, STATE_GAS, STATE_ON]
+STATE_IDLE = "idle"
+
+OPERATION_LIST = [STATE_OFF, STATE_ON]
 ATTR_RECIRCULATION_MINUTES = "recirculation_minutes"
 SERVICE_START_RECIRCULATION = "start_recirculation"
 SERVICE_STOP_RECIRCULATION = "stop_recirculation"
@@ -57,14 +59,12 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
         super().__init__("water_heater", f"{device.device_name} Water Heater", device)
 
     @property
-    def is_on(self):
-        return self._device.is_heating
-
-    @property
     def current_operation(self):
         """Return current operation"""
-        if self.is_on:
+        if self._device.is_heating:
             return STATE_GAS
+        elif self._device.is_on:
+            return STATE_IDLE
         else:
             return STATE_OFF
 


### PR DESCRIPTION
* Add a state of `Idle` to improve state messages and improve set operation mode.