### PR TITLE
Fix for incorrect temperature reporting on C or F

### DIFF
--- a/custom_components/rinnaicontrolr-ha/manifest.json
+++ b/custom_components/rinnaicontrolr-ha/manifest.json
@@ -5,6 +5,6 @@
     "documentation": "https://github.com/explosivo22/rinnaicontrolr-ha/",
     "codeowners": [ "@explosivo22" ],
     "requirements": [ "aiorinnai==0.3.2" ],
-    "version": "1.4.3",
+    "version": "1.4.4",
     "iot_class":  "cloud_polling"
 }

--- a/custom_components/rinnaicontrolr-ha/water_heater.py
+++ b/custom_components/rinnaicontrolr-ha/water_heater.py
@@ -75,8 +75,6 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
 
     @property
     def temperature_unit(self):
-        if self.hass.config.units is METRIC_SYSTEM:
-            return UnitOfTemperature.CELSIUS
         return UnitOfTemperature.FAHRENHEIT
 
     @property
@@ -98,10 +96,14 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
 
     @property
     def outlet_temperature(self):
+        if self.hass.config.units is METRIC_SYSTEM:
+            return round((self._device.outlet_temperature-32)/1.8, 1)
         return round(self._device.outlet_temperature, 1)
 
     @property
     def inlet_temperature(self):
+        if self.hass.config.units is METRIC_SYSTEM:
+            return round((self._device.inlet_temperature-32)/1.8, 1)
         return round(self._device.inlet_temperature, 1)
 
     @property


### PR DESCRIPTION
* Import pull request to fix the reported temperature of the water heater show F for the temperature followed by incorrect C marking.
* Adjustment for the temperature sensors under the water heater entity to correctly report C or F
* Fixes #42