### PR TITLE
rollback aiorinnai requirement to 0.3.3

### DIFF
--- a/custom_components/rinnaicontrolr-ha/manifest.json
+++ b/custom_components/rinnaicontrolr-ha/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/explosivo22/rinnaicontrolr-ha/",
     "codeowners": [ "@explosivo22" ],
-    "requirements": [ "aiorinnai==0.3.5" ],
-    "version": "1.4.5",
+    "requirements": [ "aiorinnai==0.3.3" ],
+    "version": "1.4.6",
     "iot_class":  "cloud_polling"
 }


### PR DESCRIPTION
* rollback aiorinnai requirement to 0.3.3 to make dependency tree match what HA is using. #90. #92 