### PR TITLE
Guard against non-string values when parsing

### DIFF
--- a/custom_components/rinnaicontrolr-ha/rinnai.py
+++ b/custom_components/rinnaicontrolr-ha/rinnai.py
@@ -160,17 +160,18 @@ class WaterHeater(object):
                     if match:
                         value = match.group(1).replace("'", "")
 
-                # Convert 'null' to None
-                if value.lower() == 'null':
-                    value = None
-                # Convert numerical strings to integers or floats
-                elif value.isdigit():
-                    value = int(value)
-                else:
-                    try:
-                        value = float(value)
-                    except ValueError:
-                        pass
+                if isinstance(value, str):
+                    # Convert 'null' to None
+                    if value.lower() == 'null':
+                        value = None
+                    # Convert numerical strings to integers or floats
+                    elif value.isdigit():
+                        value = int(value)
+                    else:
+                        try:
+                            value = float(value)
+                        except ValueError:
+                            pass
 
                 key_value_pairs[key] = value
 


### PR DESCRIPTION
When adding my local Rinnai controller to HA, I got errors like the following, and no devices would be added:

`2025-03-09 11:40:58.288 ERROR (MainThread) [custom_components.rinnai] An unexpected error occurred: 'int' object has no attribute 'isdigit'`

Seems like my particular controller returns raw integer values in some cases. I added a guard to make sure we're not trying to run string conversions on things that aren't strings, that seemed to fix my local copy.