### PR TITLE
Refactor ConfigFlow class to include domain in inheritance and update…

### DIFF
--- a/custom_components/rinnaicontrolr-ha/config_flow.py
+++ b/custom_components/rinnaicontrolr-ha/config_flow.py
@@ -21,10 +21,8 @@ from .const import (
     CONF_REFRESH_TOKEN,
 )
 
-class ConfigFlow(config_entries.ConfigFlow):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Rinnai."""
-    DOMAIN = DOMAIN
-
     VERSION = 2
 
     entry: config_entries.ConfigEntry | None

--- a/custom_components/rinnaicontrolr-ha/manifest.json
+++ b/custom_components/rinnaicontrolr-ha/manifest.json
@@ -5,6 +5,6 @@
     "documentation": "https://github.com/explosivo22/rinnaicontrolr-ha/",
     "codeowners": [ "@explosivo22" ],
     "requirements": [ "aiorinnai==0.4.0a2" ],
-    "version": "1.5.7",
+    "version": "1.5.8",
     "iot_class":  "cloud_polling"
 }


### PR DESCRIPTION
This pull request makes updates to the `RinnaiControlR-HA` integration, including improvements to the configuration flow and a version bump in the manifest file.

### Configuration flow updates:
* [`custom_components/rinnaicontrolr-ha/config_flow.py`](diffhunk://#diff-ccdda9347c7ba0027805aaa83aa7a404e00c8222a0da82be43d2f5c6c558e888L24-L27): Modified the `ConfigFlow` class to inherit the `domain` directly from `DOMAIN`, simplifying the code and removing the explicit assignment of `DOMAIN`.

### Manifest file update:
* [`custom_components/rinnaicontrolr-ha/manifest.json`](diffhunk://#diff-5a34116f23b67c5676b5557910e7a5c75b9c443ea317793538d0e69e415637cfL8-R8): Updated the integration version from `1.5.7` to `1.5.8`.… version to 1.5.8 in manifest