### PR TITLE
Change reciruculation_minutes from number to string

### DIFF
--- a/custom_components/rinnaicontrolr-ha/services.yaml
+++ b/custom_components/rinnaicontrolr-ha/services.yaml
@@ -12,27 +12,27 @@ start_recirculation:
       selector:
         select:
           options:
-            - 5
-            - 15
-            - 30
-            - 45
-            - 60
-            - 75
-            - 90
-            - 105
-            - 120
-            - 135
-            - 150
-            - 165
-            - 180
-            - 195
-            - 210
-            - 225
-            - 240
-            - 255
-            - 270
-            - 285
-            - 300
+            - "5"
+            - "15"
+            - "30"
+            - "45"
+            - "60"
+            - "75"
+            - "90"
+            - "105"
+            - "120"
+            - "135"
+            - "150"
+            - "165"
+            - "180"
+            - "195"
+            - "210"
+            - "225"
+            - "240"
+            - "255"
+            - "270"
+            - "285"
+            - "300"
 stop_recirculation:
   name: Stop Recirculation
   description: Stop recirculation on the water heater.


### PR DESCRIPTION
Address warning in Home Assistant where it was expecting a string value for the recirculation_minutes selector, but it found a number instead.

Example warning:
Logger: homeassistant.helpers.service
Source: helpers/service.py:509
First occurred: 12:33:24 PM (1 occurrence)
Last logged: 12:33:24 PM

Unable to parse services.yaml for the rinnai integration: expected str @ data['start_recirculation']['fields']['recirculation_minutes']['selector']['options'][0]