### PR TITLE
feat: configurable temperature range (98-140°F) with auto-adjustment

### DIFF
--- a/custom_components/rinnai/__init__.py
+++ b/custom_components/rinnai/__init__.py
@@ -18,11 +18,15 @@ from .const import (
     CONF_ACCESS_TOKEN,
     CONF_CONNECTION_MODE,
     CONF_HOST,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
     CONF_REFRESH_TOKEN,
     CONF_STORED_PASSWORD,
     CONNECTION_MODE_CLOUD,
     CONNECTION_MODE_HYBRID,
     CONNECTION_MODE_LOCAL,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
     DOMAIN,
 )
 from .device import RinnaiDeviceDataUpdateCoordinator
@@ -519,13 +523,24 @@ async def _async_add_entities_for_new_devices(
     from .sensor import SENSOR_DESCRIPTIONS, RinnaiSensor
     from .switch import RinnaiRecirculationSwitch
     from .water_heater import RinnaiWaterHeater
+    from .water_heater import VALID_TEMPERATURES
 
     runtime_data = entry.runtime_data
+
+    # Get configured temperature range from options
+    min_temp = entry.options.get(CONF_MIN_TEMP, DEFAULT_MIN_TEMP)
+    max_temp = entry.options.get(CONF_MAX_TEMP, DEFAULT_MAX_TEMP)
+
+    # Filter valid temperatures based on configured range
+    valid_temps_for_range = sorted(
+        [t for t in VALID_TEMPERATURES if min_temp <= t <= max_temp]
+    )
 
     # Add water heater entities
     if Platform.WATER_HEATER in runtime_data.entity_adders:
         water_heater_entities = [
-            RinnaiWaterHeater(device) for device in new_coordinators
+            RinnaiWaterHeater(device, valid_temps_for_range)
+            for device in new_coordinators
         ]
         runtime_data.entity_adders[Platform.WATER_HEATER](water_heater_entities)
         _LOGGER.debug(

--- a/custom_components/rinnai/config_flow.py
+++ b/custom_components/rinnai/config_flow.py
@@ -29,11 +29,15 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
+    ABSOLUTE_MAX_TEMP,
+    ABSOLUTE_MIN_TEMP,
     CONF_ACCESS_TOKEN,
     CONF_CONNECTION_MODE,
     CONF_HOST,
     CONF_MAINT_INTERVAL_ENABLED,
     CONF_MAINT_INTERVAL_MINUTES,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
     CONF_RECIRCULATION_DURATION,
     CONF_REFRESH_TOKEN,
     CONF_SAVE_PASSWORD,
@@ -43,6 +47,8 @@ from .const import (
     CONNECTION_MODE_LOCAL,
     DEFAULT_MAINT_INTERVAL_ENABLED,
     DEFAULT_MAINT_INTERVAL_MINUTES,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
     DEFAULT_RECIRCULATION_DURATION,
     DEFAULT_SAVE_PASSWORD,
     DOMAIN,
@@ -820,6 +826,37 @@ class OptionsFlow(config_entries.OptionsFlow):
                 ),
             )
         ] = vol.All(vol.Coerce(int), vol.Range(min=5, max=300))
+
+        # Add temperature range options
+        schema_dict[
+            vol.Optional(
+                CONF_MIN_TEMP,
+                default=self._config_entry.options.get(CONF_MIN_TEMP, DEFAULT_MIN_TEMP),
+            )
+        ] = NumberSelector(
+            NumberSelectorConfig(
+                min=ABSOLUTE_MIN_TEMP,
+                max=ABSOLUTE_MAX_TEMP,
+                step=1,
+                mode=NumberSelectorMode.BOX,
+                unit_of_measurement="°F",
+            )
+        )
+
+        schema_dict[
+            vol.Optional(
+                CONF_MAX_TEMP,
+                default=self._config_entry.options.get(CONF_MAX_TEMP, DEFAULT_MAX_TEMP),
+            )
+        ] = NumberSelector(
+            NumberSelectorConfig(
+                min=ABSOLUTE_MIN_TEMP,
+                max=ABSOLUTE_MAX_TEMP,
+                step=1,
+                mode=NumberSelectorMode.BOX,
+                unit_of_measurement="°F",
+            )
+        )
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/rinnai/const.py
+++ b/custom_components/rinnai/const.py
@@ -23,6 +23,14 @@ MAX_MAINT_INTERVAL_MINUTES: Final = 60
 CONF_RECIRCULATION_DURATION: Final = "recirculation_duration"
 DEFAULT_RECIRCULATION_DURATION: Final = 10
 
+# Temperature range configuration
+CONF_MIN_TEMP: Final = "min_temp"
+CONF_MAX_TEMP: Final = "max_temp"
+DEFAULT_MIN_TEMP: Final = 110  # Conservative default for safety
+DEFAULT_MAX_TEMP: Final = 140
+ABSOLUTE_MIN_TEMP: Final = 98  # Hardware absolute minimum
+ABSOLUTE_MAX_TEMP: Final = 140  # Hardware absolute maximum
+
 # Token storage keys
 CONF_REFRESH_TOKEN: Final = "conf_refresh_token"
 CONF_ACCESS_TOKEN: Final = "conf_access_token"

--- a/custom_components/rinnai/strings.json
+++ b/custom_components/rinnai/strings.json
@@ -139,12 +139,16 @@
                 "data": {
                     "maint_interval_enabled": "Enable maintenance data retrieval",
                     "maint_interval_minutes": "Maintenance retrieval interval",
-                    "recirculation_duration": "Recirculation Duration"
+                    "recirculation_duration": "Recirculation Duration",
+                    "min_temp": "Minimum Temperature",
+                    "max_temp": "Maximum Temperature"
                 },
                 "data_description": {
                     "maint_interval_enabled": "When enabled, retrieves detailed maintenance data from the device at the specified interval. This may increase API usage.",
                     "maint_interval_minutes": "How often to retrieve maintenance data from the device (in minutes). Lower values provide more frequent updates but increase API usage. Only available for Local and Hybrid connection modes.",
-                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on."
+                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on.",
+                    "min_temp": "Minimum allowed temperature for your water heater (98-140°F). Hardware supports down to 98°F, but 110°F is recommended for safety. Only valid setpoints within your range will be available: 98, 100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 135, 140°F.",
+                    "max_temp": "Maximum allowed temperature for your water heater (98-140°F). Default is 140°F. Only valid setpoints within your range will be available."
                 }
             }
         }

--- a/custom_components/rinnai/translations/en.json
+++ b/custom_components/rinnai/translations/en.json
@@ -138,12 +138,16 @@
                 "data": {
                     "maint_interval_enabled": "Enable maintenance data retrieval",
                     "maint_interval_minutes": "Maintenance retrieval interval",
-                    "recirculation_duration": "Recirculation Duration"
+                    "recirculation_duration": "Recirculation Duration",
+                    "min_temp": "Minimum Temperature",
+                    "max_temp": "Maximum Temperature"
                 },
                 "data_description": {
                     "maint_interval_enabled": "When enabled, retrieves detailed maintenance data from the device at the specified interval. This may increase API usage.",
                     "maint_interval_minutes": "How often to retrieve maintenance data from the device (in minutes). Lower values provide more frequent updates but increase API usage. Only available for Local and Hybrid connection modes.",
-                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on."
+                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on.",
+                    "min_temp": "Minimum allowed temperature for your water heater (98-140°F). Hardware supports down to 98°F, but 110°F is recommended for safety. Only valid setpoints within your range will be available: 98, 100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 135, 140°F.",
+                    "max_temp": "Maximum allowed temperature for your water heater (98-140°F). Default is 140°F. Only valid setpoints within your range will be available."
                 }
             }
         }

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -62,9 +62,18 @@ RECIRCULATION_MINUTE_OPTIONS = {
 }
 
 # Temperature limits in Fahrenheit
-MIN_TEMP_F = 110
+MIN_TEMP_F = 98
 MAX_TEMP_F = 140
-TEMP_STEP = 5
+TEMP_STEP = 1  # Allows UI to select any value, validation restricts to valid setpoints
+
+# Valid temperature setpoints in Fahrenheit
+# Note: Non-uniform increments (2°F from 98-110, then 5°F from 110-140)
+VALID_TEMPERATURES = {
+    98, 100, 102, 104, 106, 108,
+    110, 115, 120, 125, 130, 135, 140
+}
+
+VALID_TEMP_LIST = sorted(VALID_TEMPERATURES)
 
 
 async def async_setup_entry(
@@ -197,12 +206,30 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
             LOGGER.warning("async_set_temperature called without target temperature")
             return
 
-        # Validate temperature range
-        if not (MIN_TEMP_F <= target_temp <= MAX_TEMP_F):
-            raise ServiceValidationError(
-                f"Temperature must be between {MIN_TEMP_F}°F and {MAX_TEMP_F}°F, "
-                f"got {target_temp}°F"
-            )
+        # Validate temperature is within valid setpoints
+        # If not valid, automatically round down to nearest valid temperature
+        if target_temp not in VALID_TEMPERATURES:
+            # Find the highest valid temperature that's <= target_temp
+            valid_below = [t for t in VALID_TEMP_LIST if t <= target_temp]
+
+            if valid_below:
+                # Round down to nearest valid temperature
+                adjusted_temp = valid_below[-1]
+                LOGGER.info(
+                    "Temperature %s°F is not valid, adjusting to %s°F on %s",
+                    target_temp,
+                    adjusted_temp,
+                    self._device.device_name,
+                )
+                target_temp = adjusted_temp
+            else:
+                # User selected below minimum, use minimum
+                target_temp = VALID_TEMP_LIST[0]
+                LOGGER.info(
+                    "Temperature below minimum, using %s°F on %s",
+                    target_temp,
+                    self._device.device_name,
+                )
 
         LOGGER.info(
             "Setting target temperature to %s°F on %s",

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -22,7 +22,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import RinnaiConfigEntry
-from .const import LOGGER
+from .const import (
+    ABSOLUTE_MAX_TEMP,
+    ABSOLUTE_MIN_TEMP,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    LOGGER,
+)
 from .device import RinnaiDeviceDataUpdateCoordinator
 from .entity import RinnaiEntity
 
@@ -62,8 +70,9 @@ RECIRCULATION_MINUTE_OPTIONS = {
 }
 
 # Temperature limits in Fahrenheit
-MIN_TEMP_F = 98
-MAX_TEMP_F = 140
+# Note: These are hardware limits - actual limits are configurable per user
+HARDWARE_MIN_TEMP_F = ABSOLUTE_MIN_TEMP
+HARDWARE_MAX_TEMP_F = ABSOLUTE_MAX_TEMP
 TEMP_STEP = 1  # Allows UI to select any value, validation restricts to valid setpoints
 
 # Valid temperature setpoints in Fahrenheit
@@ -87,9 +96,26 @@ async def async_setup_entry(
 
     config_entry.runtime_data.entity_adders[Platform.WATER_HEATER] = async_add_entities
 
+    # Get configured temperature range from options
+    min_temp = config_entry.options.get(CONF_MIN_TEMP, DEFAULT_MIN_TEMP)
+    max_temp = config_entry.options.get(CONF_MAX_TEMP, DEFAULT_MAX_TEMP)
+
+    # Filter valid temperatures based on configured range
+    valid_temps_for_range = sorted(
+        [t for t in VALID_TEMPERATURES if min_temp <= t <= max_temp]
+    )
+
+    LOGGER.debug(
+        "Setting up water heater with temp range %d-%d°F (%d valid setpoints)",
+        min_temp,
+        max_temp,
+        len(valid_temps_for_range),
+    )
+
     LOGGER.debug("Setting up Rinnai water heater entities")
     entities = [
-        RinnaiWaterHeater(device) for device in config_entry.runtime_data.devices
+        RinnaiWaterHeater(device, valid_temps_for_range)
+        for device in config_entry.runtime_data.devices
     ]
     async_add_entities(entities)
     LOGGER.debug("Added %d water heater entities", len(entities))
@@ -121,14 +147,19 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
         | WaterHeaterEntityFeature.TARGET_TEMPERATURE
     )
     _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
-    _attr_min_temp = float(MIN_TEMP_F)
-    _attr_max_temp = float(MAX_TEMP_F)
     _attr_target_temperature_step = float(TEMP_STEP)
     _attr_translation_key = "water_heater"
 
-    def __init__(self, device: RinnaiDeviceDataUpdateCoordinator) -> None:
+    def __init__(
+        self,
+        device: RinnaiDeviceDataUpdateCoordinator,
+        valid_temperatures: list[int],
+    ) -> None:
         """Initialize the water heater."""
         super().__init__("water_heater", device)
+        self._valid_temperatures = valid_temperatures
+        self._attr_min_temp = float(valid_temperatures[0])
+        self._attr_max_temp = float(valid_temperatures[-1])
 
     @property
     def current_operation(self) -> str:
@@ -208,9 +239,9 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
 
         # Validate temperature is within valid setpoints
         # If not valid, automatically round down to nearest valid temperature
-        if target_temp not in VALID_TEMPERATURES:
+        if target_temp not in self._valid_temperatures:
             # Find the highest valid temperature that's <= target_temp
-            valid_below = [t for t in VALID_TEMP_LIST if t <= target_temp]
+            valid_below = [t for t in self._valid_temperatures if t <= target_temp]
 
             if valid_below:
                 # Round down to nearest valid temperature
@@ -224,7 +255,7 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
                 target_temp = adjusted_temp
             else:
                 # User selected below minimum, use minimum
-                target_temp = VALID_TEMP_LIST[0]
+                target_temp = self._valid_temperatures[0]
                 LOGGER.info(
                     "Temperature below minimum, using %s°F on %s",
                     target_temp,

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -16,7 +16,6 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_conversion import TemperatureConverter
@@ -77,10 +76,7 @@ TEMP_STEP = 1  # Allows UI to select any value, validation restricts to valid se
 
 # Valid temperature setpoints in Fahrenheit
 # Note: Non-uniform increments (2°F from 98-110, then 5°F from 110-140)
-VALID_TEMPERATURES = {
-    98, 100, 102, 104, 106, 108,
-    110, 115, 120, 125, 130, 135, 140
-}
+VALID_TEMPERATURES = {98, 100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 135, 140}
 
 VALID_TEMP_LIST = sorted(VALID_TEMPERATURES)
 

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -237,30 +237,24 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
             LOGGER.warning("async_set_temperature called without target temperature")
             return
 
-        # Validate temperature is within valid setpoints
-        # If not valid, automatically round down to nearest valid temperature
-        if target_temp not in self._valid_temperatures:
-            # Find the highest valid temperature that's <= target_temp
-            valid_below = [t for t in self._valid_temperatures if t <= target_temp]
+        # Round to nearest integer for validation (handles Celsius conversions like 40°C = 103.82°F → 104°F)
+        target_temp = round(target_temp)
 
-            if valid_below:
-                # Round down to nearest valid temperature
-                adjusted_temp = valid_below[-1]
-                LOGGER.info(
-                    "Temperature %s°F is not valid, adjusting to %s°F on %s",
-                    target_temp,
-                    adjusted_temp,
-                    self._device.device_name,
-                )
-                target_temp = adjusted_temp
-            else:
-                # User selected below minimum, use minimum
-                target_temp = self._valid_temperatures[0]
-                LOGGER.info(
-                    "Temperature below minimum, using %s°F on %s",
-                    target_temp,
-                    self._device.device_name,
-                )
+        # Validate temperature is within valid setpoints
+        # If still not valid after rounding, automatically adjust to nearest valid temperature
+        if target_temp not in self._valid_temperatures:
+            # Find the nearest valid temperature (prefer lower if equidistant for safety)
+            nearest_temp = min(
+                self._valid_temperatures, key=lambda t: (abs(t - target_temp), t)
+            )
+
+            LOGGER.info(
+                "Temperature %s°F is not a valid setpoint, adjusting to nearest valid %s°F on %s",
+                target_temp,
+                nearest_temp,
+                self._device.device_name,
+            )
+            target_temp = nearest_temp
 
         LOGGER.info(
             "Setting target temperature to %s°F on %s",


### PR DESCRIPTION
## Summary
Adds configurable min/max temperature range UI with intelligent temperature auto-adjustment to nearest valid setpoint.

Implements feature request from #100

## Features
- 🎛️ **Configurable range**: Users can set min/max temperature (98-140°F) via integration options
- 🛡️ **Safe defaults**: Existing installations default to 110-140°F (no breaking changes)
- 🌡️ **Extended range**: Support for 98-108°F (2°F increments) for cooler water needs
- 🔄 **Smart auto-adjustment**: Invalid temperatures automatically snap to nearest valid setpoint (not just rounding down)

## Valid Temperature Setpoints
13 temperatures: **98, 100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 135, 140°F**
- 98-110°F: 2°F increments
- 110-140°F: 5°F increments

## UI Configuration
New options in integration settings (Configuration → Integrations → Rinnai → Configure):
- **Minimum Temperature** (default: 110°F, range: 98-140°F)
- **Maximum Temperature** (default: 140°F, range: 98-140°F)

Users can restrict the range (e.g., 110-130°F for safety) or extend it (e.g., 98-140°F for cooler water) based on their needs.

## Use Cases
- **Extended range (98-140°F)**: Users who need cooler water temperatures
- **Default range (110-140°F)**: Existing users - no change in behavior
- **Restricted range (e.g., 110-130°F)**: Users who want to limit maximum temperature for safety
- **Celsius users**: Properly handles fractional Fahrenheit conversions (40°C → 104°F)
- **Fahrenheit slider users**: Smoothly adjusts in-between values to valid setpoints

## Changes
- Added `CONF_MIN_TEMP` and `CONF_MAX_TEMP` configuration options with defaults
- Updated `config_flow.py` with NumberSelector UI controls (box mode, 1°F step)
- Modified `water_heater.py` to filter valid temperatures based on user configuration
- Implemented nearest-neighbor temperature adjustment algorithm (prefers lower temp when equidistant for safety)
- Updated translations (English + base strings.json)
- Replaced validation errors with automatic adjustment (better UX)

## Temperature Auto-Adjustment Algorithm
When a user selects an invalid temperature (from Celsius conversion, slider, or automation):
1. Rounds to nearest integer (e.g., 103.82°F → 104°F)
2. Finds nearest valid setpoint from configured range
3. Prefers lower temperature when equidistant (safety first)
4. Logs adjustment for debugging

**Examples:**
- 114°F → 115°F (rounds up to nearest)
- 113°F → 110°F (equidistant, prefers lower)
- 95°F → 98°F (below minimum)
- 145°F → 140°F (above maximum)

## Testing
- ✅ All 95 existing tests pass
- ✅ Linting passes (ruff check + format)
- ✅ Backward compatible - existing installations maintain 110-140°F default
- ✅ Manual testing with Fahrenheit and Celsius users
- ✅ GitHub Actions CI will validate integration loading and platform setup

## Breaking Changes
**None** - existing installations automatically use 110-140°F defaults. Users must explicitly opt-in to extended range via integration configuration.

## Commits
- `8b44ea2` - feat: expand temperature range to 98-140°F with auto-adjustment
- `0d5cf28` - feat: add configurable min/max temperature range in UI
- `0f38d61` - fix: round Celsius temperature conversions before validation
- `7dee768` - chore: fix linting issues

## Related
Closes #100