### PR TITLE
2.0.0 beta

### DIFF
--- a/custom_components/rinnai/__init__.py
+++ b/custom_components/rinnai/__init__.py
@@ -18,11 +18,15 @@ from .const import (
     CONF_ACCESS_TOKEN,
     CONF_CONNECTION_MODE,
     CONF_HOST,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
     CONF_REFRESH_TOKEN,
     CONF_STORED_PASSWORD,
     CONNECTION_MODE_CLOUD,
     CONNECTION_MODE_HYBRID,
     CONNECTION_MODE_LOCAL,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
     DOMAIN,
 )
 from .device import RinnaiDeviceDataUpdateCoordinator
@@ -519,13 +523,24 @@ async def _async_add_entities_for_new_devices(
     from .sensor import SENSOR_DESCRIPTIONS, RinnaiSensor
     from .switch import RinnaiRecirculationSwitch
     from .water_heater import RinnaiWaterHeater
+    from .water_heater import VALID_TEMPERATURES
 
     runtime_data = entry.runtime_data
+
+    # Get configured temperature range from options
+    min_temp = entry.options.get(CONF_MIN_TEMP, DEFAULT_MIN_TEMP)
+    max_temp = entry.options.get(CONF_MAX_TEMP, DEFAULT_MAX_TEMP)
+
+    # Filter valid temperatures based on configured range
+    valid_temps_for_range = sorted(
+        [t for t in VALID_TEMPERATURES if min_temp <= t <= max_temp]
+    )
 
     # Add water heater entities
     if Platform.WATER_HEATER in runtime_data.entity_adders:
         water_heater_entities = [
-            RinnaiWaterHeater(device) for device in new_coordinators
+            RinnaiWaterHeater(device, valid_temps_for_range)
+            for device in new_coordinators
         ]
         runtime_data.entity_adders[Platform.WATER_HEATER](water_heater_entities)
         _LOGGER.debug(

--- a/custom_components/rinnai/config_flow.py
+++ b/custom_components/rinnai/config_flow.py
@@ -29,11 +29,15 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
+    ABSOLUTE_MAX_TEMP,
+    ABSOLUTE_MIN_TEMP,
     CONF_ACCESS_TOKEN,
     CONF_CONNECTION_MODE,
     CONF_HOST,
     CONF_MAINT_INTERVAL_ENABLED,
     CONF_MAINT_INTERVAL_MINUTES,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
     CONF_RECIRCULATION_DURATION,
     CONF_REFRESH_TOKEN,
     CONF_SAVE_PASSWORD,
@@ -43,6 +47,8 @@ from .const import (
     CONNECTION_MODE_LOCAL,
     DEFAULT_MAINT_INTERVAL_ENABLED,
     DEFAULT_MAINT_INTERVAL_MINUTES,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
     DEFAULT_RECIRCULATION_DURATION,
     DEFAULT_SAVE_PASSWORD,
     DOMAIN,
@@ -820,6 +826,37 @@ class OptionsFlow(config_entries.OptionsFlow):
                 ),
             )
         ] = vol.All(vol.Coerce(int), vol.Range(min=5, max=300))
+
+        # Add temperature range options
+        schema_dict[
+            vol.Optional(
+                CONF_MIN_TEMP,
+                default=self._config_entry.options.get(CONF_MIN_TEMP, DEFAULT_MIN_TEMP),
+            )
+        ] = NumberSelector(
+            NumberSelectorConfig(
+                min=ABSOLUTE_MIN_TEMP,
+                max=ABSOLUTE_MAX_TEMP,
+                step=1,
+                mode=NumberSelectorMode.BOX,
+                unit_of_measurement="°F",
+            )
+        )
+
+        schema_dict[
+            vol.Optional(
+                CONF_MAX_TEMP,
+                default=self._config_entry.options.get(CONF_MAX_TEMP, DEFAULT_MAX_TEMP),
+            )
+        ] = NumberSelector(
+            NumberSelectorConfig(
+                min=ABSOLUTE_MIN_TEMP,
+                max=ABSOLUTE_MAX_TEMP,
+                step=1,
+                mode=NumberSelectorMode.BOX,
+                unit_of_measurement="°F",
+            )
+        )
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/rinnai/const.py
+++ b/custom_components/rinnai/const.py
@@ -23,6 +23,14 @@ MAX_MAINT_INTERVAL_MINUTES: Final = 60
 CONF_RECIRCULATION_DURATION: Final = "recirculation_duration"
 DEFAULT_RECIRCULATION_DURATION: Final = 10
 
+# Temperature range configuration
+CONF_MIN_TEMP: Final = "min_temp"
+CONF_MAX_TEMP: Final = "max_temp"
+DEFAULT_MIN_TEMP: Final = 110  # Conservative default for safety
+DEFAULT_MAX_TEMP: Final = 140
+ABSOLUTE_MIN_TEMP: Final = 98  # Hardware absolute minimum
+ABSOLUTE_MAX_TEMP: Final = 140  # Hardware absolute maximum
+
 # Token storage keys
 CONF_REFRESH_TOKEN: Final = "conf_refresh_token"
 CONF_ACCESS_TOKEN: Final = "conf_access_token"

--- a/custom_components/rinnai/manifest.json
+++ b/custom_components/rinnai/manifest.json
@@ -8,5 +8,5 @@
     "issue_tracker": "https://github.com/explosivo22/rinnaicontrolr-ha/issues",
     "quality_scale": "platinum",
     "requirements": ["aiorinnai==0.5.1", "PyJWT>=2.0.0"],
-    "version": "2.2.6"
+    "version": "2.3.0"
 }

--- a/custom_components/rinnai/strings.json
+++ b/custom_components/rinnai/strings.json
@@ -139,12 +139,16 @@
                 "data": {
                     "maint_interval_enabled": "Enable maintenance data retrieval",
                     "maint_interval_minutes": "Maintenance retrieval interval",
-                    "recirculation_duration": "Recirculation Duration"
+                    "recirculation_duration": "Recirculation Duration",
+                    "min_temp": "Minimum Temperature",
+                    "max_temp": "Maximum Temperature"
                 },
                 "data_description": {
                     "maint_interval_enabled": "When enabled, retrieves detailed maintenance data from the device at the specified interval. This may increase API usage.",
                     "maint_interval_minutes": "How often to retrieve maintenance data from the device (in minutes). Lower values provide more frequent updates but increase API usage. Only available for Local and Hybrid connection modes.",
-                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on."
+                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on.",
+                    "min_temp": "Minimum allowed temperature for your water heater (98-140°F). Hardware supports down to 98°F, but 110°F is recommended for safety. Only valid setpoints within your range will be available: 98, 100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 135, 140°F.",
+                    "max_temp": "Maximum allowed temperature for your water heater (98-140°F). Default is 140°F. Only valid setpoints within your range will be available."
                 }
             }
         }

--- a/custom_components/rinnai/translations/en.json
+++ b/custom_components/rinnai/translations/en.json
@@ -138,12 +138,16 @@
                 "data": {
                     "maint_interval_enabled": "Enable maintenance data retrieval",
                     "maint_interval_minutes": "Maintenance retrieval interval",
-                    "recirculation_duration": "Recirculation Duration"
+                    "recirculation_duration": "Recirculation Duration",
+                    "min_temp": "Minimum Temperature",
+                    "max_temp": "Maximum Temperature"
                 },
                 "data_description": {
                     "maint_interval_enabled": "When enabled, retrieves detailed maintenance data from the device at the specified interval. This may increase API usage.",
                     "maint_interval_minutes": "How often to retrieve maintenance data from the device (in minutes). Lower values provide more frequent updates but increase API usage. Only available for Local and Hybrid connection modes.",
-                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on."
+                    "recirculation_duration": "Duration in minutes (5-300) used by the Recirculation switch entity when turned on.",
+                    "min_temp": "Minimum allowed temperature for your water heater (98-140°F). Hardware supports down to 98°F, but 110°F is recommended for safety. Only valid setpoints within your range will be available: 98, 100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 135, 140°F.",
+                    "max_temp": "Maximum allowed temperature for your water heater (98-140°F). Default is 140°F. Only valid setpoints within your range will be available."
                 }
             }
         }

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -90,8 +90,8 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_START_RECIRCULATION,
         {
-            vol.Required(ATTR_RECIRCULATION_MINUTES, default=5): vol.In(
-                RECIRCULATION_MINUTE_OPTIONS
+            vol.Required(ATTR_RECIRCULATION_MINUTES, default=5): vol.All(
+                vol.Coerce(int), vol.In(RECIRCULATION_MINUTE_OPTIONS)
             )
         },
         "async_start_recirculation",

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -62,9 +62,18 @@ RECIRCULATION_MINUTE_OPTIONS = {
 }
 
 # Temperature limits in Fahrenheit
-MIN_TEMP_F = 110
+MIN_TEMP_F = 98
 MAX_TEMP_F = 140
-TEMP_STEP = 5
+TEMP_STEP = 1  # Allows UI to select any value, validation restricts to valid setpoints
+
+# Valid temperature setpoints in Fahrenheit
+# Note: Non-uniform increments (2°F from 98-110, then 5°F from 110-140)
+VALID_TEMPERATURES = {
+    98, 100, 102, 104, 106, 108,
+    110, 115, 120, 125, 130, 135, 140
+}
+
+VALID_TEMP_LIST = sorted(VALID_TEMPERATURES)
 
 
 async def async_setup_entry(
@@ -197,12 +206,30 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
             LOGGER.warning("async_set_temperature called without target temperature")
             return
 
-        # Validate temperature range
-        if not (MIN_TEMP_F <= target_temp <= MAX_TEMP_F):
-            raise ServiceValidationError(
-                f"Temperature must be between {MIN_TEMP_F}°F and {MAX_TEMP_F}°F, "
-                f"got {target_temp}°F"
-            )
+        # Validate temperature is within valid setpoints
+        # If not valid, automatically round down to nearest valid temperature
+        if target_temp not in VALID_TEMPERATURES:
+            # Find the highest valid temperature that's <= target_temp
+            valid_below = [t for t in VALID_TEMP_LIST if t <= target_temp]
+
+            if valid_below:
+                # Round down to nearest valid temperature
+                adjusted_temp = valid_below[-1]
+                LOGGER.info(
+                    "Temperature %s°F is not valid, adjusting to %s°F on %s",
+                    target_temp,
+                    adjusted_temp,
+                    self._device.device_name,
+                )
+                target_temp = adjusted_temp
+            else:
+                # User selected below minimum, use minimum
+                target_temp = VALID_TEMP_LIST[0]
+                LOGGER.info(
+                    "Temperature below minimum, using %s°F on %s",
+                    target_temp,
+                    self._device.device_name,
+                )
 
         LOGGER.info(
             "Setting target temperature to %s°F on %s",

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -22,7 +22,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import RinnaiConfigEntry
-from .const import LOGGER
+from .const import (
+    ABSOLUTE_MAX_TEMP,
+    ABSOLUTE_MIN_TEMP,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    LOGGER,
+)
 from .device import RinnaiDeviceDataUpdateCoordinator
 from .entity import RinnaiEntity
 
@@ -62,8 +70,9 @@ RECIRCULATION_MINUTE_OPTIONS = {
 }
 
 # Temperature limits in Fahrenheit
-MIN_TEMP_F = 98
-MAX_TEMP_F = 140
+# Note: These are hardware limits - actual limits are configurable per user
+HARDWARE_MIN_TEMP_F = ABSOLUTE_MIN_TEMP
+HARDWARE_MAX_TEMP_F = ABSOLUTE_MAX_TEMP
 TEMP_STEP = 1  # Allows UI to select any value, validation restricts to valid setpoints
 
 # Valid temperature setpoints in Fahrenheit
@@ -87,9 +96,26 @@ async def async_setup_entry(
 
     config_entry.runtime_data.entity_adders[Platform.WATER_HEATER] = async_add_entities
 
+    # Get configured temperature range from options
+    min_temp = config_entry.options.get(CONF_MIN_TEMP, DEFAULT_MIN_TEMP)
+    max_temp = config_entry.options.get(CONF_MAX_TEMP, DEFAULT_MAX_TEMP)
+
+    # Filter valid temperatures based on configured range
+    valid_temps_for_range = sorted(
+        [t for t in VALID_TEMPERATURES if min_temp <= t <= max_temp]
+    )
+
+    LOGGER.debug(
+        "Setting up water heater with temp range %d-%d°F (%d valid setpoints)",
+        min_temp,
+        max_temp,
+        len(valid_temps_for_range),
+    )
+
     LOGGER.debug("Setting up Rinnai water heater entities")
     entities = [
-        RinnaiWaterHeater(device) for device in config_entry.runtime_data.devices
+        RinnaiWaterHeater(device, valid_temps_for_range)
+        for device in config_entry.runtime_data.devices
     ]
     async_add_entities(entities)
     LOGGER.debug("Added %d water heater entities", len(entities))
@@ -121,14 +147,19 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
         | WaterHeaterEntityFeature.TARGET_TEMPERATURE
     )
     _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
-    _attr_min_temp = float(MIN_TEMP_F)
-    _attr_max_temp = float(MAX_TEMP_F)
     _attr_target_temperature_step = float(TEMP_STEP)
     _attr_translation_key = "water_heater"
 
-    def __init__(self, device: RinnaiDeviceDataUpdateCoordinator) -> None:
+    def __init__(
+        self,
+        device: RinnaiDeviceDataUpdateCoordinator,
+        valid_temperatures: list[int],
+    ) -> None:
         """Initialize the water heater."""
         super().__init__("water_heater", device)
+        self._valid_temperatures = valid_temperatures
+        self._attr_min_temp = float(valid_temperatures[0])
+        self._attr_max_temp = float(valid_temperatures[-1])
 
     @property
     def current_operation(self) -> str:
@@ -208,9 +239,9 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
 
         # Validate temperature is within valid setpoints
         # If not valid, automatically round down to nearest valid temperature
-        if target_temp not in VALID_TEMPERATURES:
+        if target_temp not in self._valid_temperatures:
             # Find the highest valid temperature that's <= target_temp
-            valid_below = [t for t in VALID_TEMP_LIST if t <= target_temp]
+            valid_below = [t for t in self._valid_temperatures if t <= target_temp]
 
             if valid_below:
                 # Round down to nearest valid temperature
@@ -224,7 +255,7 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
                 target_temp = adjusted_temp
             else:
                 # User selected below minimum, use minimum
-                target_temp = VALID_TEMP_LIST[0]
+                target_temp = self._valid_temperatures[0]
                 LOGGER.info(
                     "Temperature below minimum, using %s°F on %s",
                     target_temp,

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -16,7 +16,6 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_conversion import TemperatureConverter
@@ -77,10 +76,7 @@ TEMP_STEP = 1  # Allows UI to select any value, validation restricts to valid se
 
 # Valid temperature setpoints in Fahrenheit
 # Note: Non-uniform increments (2°F from 98-110, then 5°F from 110-140)
-VALID_TEMPERATURES = {
-    98, 100, 102, 104, 106, 108,
-    110, 115, 120, 125, 130, 135, 140
-}
+VALID_TEMPERATURES = {98, 100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 135, 140}
 
 VALID_TEMP_LIST = sorted(VALID_TEMPERATURES)
 

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -237,30 +237,24 @@ class RinnaiWaterHeater(RinnaiEntity, WaterHeaterEntity):
             LOGGER.warning("async_set_temperature called without target temperature")
             return
 
-        # Validate temperature is within valid setpoints
-        # If not valid, automatically round down to nearest valid temperature
-        if target_temp not in self._valid_temperatures:
-            # Find the highest valid temperature that's <= target_temp
-            valid_below = [t for t in self._valid_temperatures if t <= target_temp]
+        # Round to nearest integer for validation (handles Celsius conversions like 40°C = 103.82°F → 104°F)
+        target_temp = round(target_temp)
 
-            if valid_below:
-                # Round down to nearest valid temperature
-                adjusted_temp = valid_below[-1]
-                LOGGER.info(
-                    "Temperature %s°F is not valid, adjusting to %s°F on %s",
-                    target_temp,
-                    adjusted_temp,
-                    self._device.device_name,
-                )
-                target_temp = adjusted_temp
-            else:
-                # User selected below minimum, use minimum
-                target_temp = self._valid_temperatures[0]
-                LOGGER.info(
-                    "Temperature below minimum, using %s°F on %s",
-                    target_temp,
-                    self._device.device_name,
-                )
+        # Validate temperature is within valid setpoints
+        # If still not valid after rounding, automatically adjust to nearest valid temperature
+        if target_temp not in self._valid_temperatures:
+            # Find the nearest valid temperature (prefer lower if equidistant for safety)
+            nearest_temp = min(
+                self._valid_temperatures, key=lambda t: (abs(t - target_temp), t)
+            )
+
+            LOGGER.info(
+                "Temperature %s°F is not a valid setpoint, adjusting to nearest valid %s°F on %s",
+                target_temp,
+                nearest_temp,
+                self._device.device_name,
+            )
+            target_temp = nearest_temp
 
         LOGGER.info(
             "Setting target temperature to %s°F on %s",

--- a/tests/test_e2e_config_entry.py
+++ b/tests/test_e2e_config_entry.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import sys
 import types
 import pathlib
 import importlib.util
 import shutil
+from unittest.mock import AsyncMock
+
 import pytest
+import voluptuous as vol
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.helpers import entity_registry as er
@@ -274,3 +279,135 @@ async def test_end_to_end_config_entry_sets_up_platforms(
     assert any(e.domain == "water_heater" for e in created)
     assert any(e.domain == "sensor" for e in created)
     assert any(e.domain == "binary_sensor" for e in created)
+
+
+async def _setup_entry(hass, monkeypatch):
+    """Shared helper: set up the integration end-to-end and return (entry, mod)."""
+    _install_fake_aiorinnai(monkeypatch)
+    mod = _preload_integration()
+    _materialize_custom_component(hass)
+
+    async def _fake_refresh(self):
+        self._device_information = await self.api_client.device.get_info(self.id)
+        return None
+
+    monkeypatch.setattr(
+        mod.RinnaiDeviceDataUpdateCoordinator, "async_refresh", _fake_refresh
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "email": "test@example.com",
+            "conf_access_token": "access",
+            "conf_refresh_token": "refresh",
+        },
+        options={"maint_interval_enabled": False},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry, mod
+
+
+def _get_water_heater_entity_id(hass, entry) -> str:
+    registry = er.async_get(hass)
+    for e in registry.entities.values():
+        if e.config_entry_id == entry.entry_id and e.domain == "water_heater":
+            return e.entity_id
+    raise AssertionError("water_heater entity not found")
+
+
+@pytest.mark.asyncio
+async def test_start_recirculation_service_coerces_string_minutes(
+    hass, enable_custom_integrations, monkeypatch
+):
+    """Regression test for #162: service must accept string "5" from UI selector.
+
+    The services.yaml `select` selector emits string values, but the schema
+    previously used `vol.In({int, ...})` which rejected strings. The fix wraps
+    the validator with `vol.Coerce(int)` so string inputs are converted before
+    membership check.
+    """
+    entry, mod = await _setup_entry(hass, monkeypatch)
+    entity_id = _get_water_heater_entity_id(hass, entry)
+
+    mock_start = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        mod.RinnaiDeviceDataUpdateCoordinator,
+        "async_start_recirculation",
+        mock_start,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "start_recirculation",
+        {"recirculation_minutes": "5"},
+        target={"entity_id": entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert mock_start.await_count == 1
+    # Coordinator method receives the int after coercion.
+    args, kwargs = mock_start.call_args
+    # First positional arg is the duration (after `self`, which AsyncMock omits
+    # when patching as a class attribute via monkeypatch).
+    duration = args[0] if args else kwargs.get("duration")
+    assert duration == 5
+    assert isinstance(duration, int)
+
+
+@pytest.mark.asyncio
+async def test_start_recirculation_service_rejects_invalid_minutes(
+    hass, enable_custom_integrations, monkeypatch
+):
+    """Values outside RECIRCULATION_MINUTE_OPTIONS must be rejected."""
+    entry, mod = await _setup_entry(hass, monkeypatch)
+    entity_id = _get_water_heater_entity_id(hass, entry)
+
+    mock_start = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        mod.RinnaiDeviceDataUpdateCoordinator,
+        "async_start_recirculation",
+        mock_start,
+    )
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "start_recirculation",
+            {"recirculation_minutes": "7"},
+            target={"entity_id": entity_id},
+            blocking=True,
+        )
+
+    assert mock_start.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_recirculation_service_no_params(
+    hass, enable_custom_integrations, monkeypatch
+):
+    """`stop_recirculation` takes no params and must call the coordinator."""
+    entry, mod = await _setup_entry(hass, monkeypatch)
+    entity_id = _get_water_heater_entity_id(hass, entry)
+
+    mock_stop = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        mod.RinnaiDeviceDataUpdateCoordinator,
+        "async_stop_recirculation",
+        mock_stop,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "stop_recirculation",
+        {},
+        target={"entity_id": entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert mock_stop.await_count == 1


### PR DESCRIPTION
This pull request introduces configurable minimum and maximum temperature settings for the Rinnai water heater integration, allowing users to restrict the available temperature setpoints within hardware limits. It also improves validation and user experience for temperature selection, and adds regression tests for recirculation services.

**Temperature range configuration and validation:**

* Added new options (`min_temp` and `max_temp`) to the integration configuration, allowing users to set the allowed temperature range for their water heater between the hardware-supported minimum (98°F) and maximum (140°F). The UI and service logic now only permit setpoints within this range, and the code automatically adjusts to the nearest valid setpoint if an invalid value is provided. [[1]](diffhunk://#diff-c4b2ebf0227b6004afa657888cfdd2beab4e51addee12b1c81a201f62f284ee1R26-R33) [[2]](diffhunk://#diff-247a720bfff4b9813fb0c48c9c6d70c137f5105f0dba1e75a94406fa03937204R32-R40) [[3]](diffhunk://#diff-247a720bfff4b9813fb0c48c9c6d70c137f5105f0dba1e75a94406fa03937204R50-R51) [[4]](diffhunk://#diff-247a720bfff4b9813fb0c48c9c6d70c137f5105f0dba1e75a94406fa03937204R830-R860) [[5]](diffhunk://#diff-6bda8344920ce789512f5d2b690b830b83fd8b3136a994277128f1b8334ba37aR21-R29) [[6]](diffhunk://#diff-6bda8344920ce789512f5d2b690b830b83fd8b3136a994277128f1b8334ba37aR526-R543) [[7]](diffhunk://#diff-8756049a55982116ad8e389b22df4cd8609af1f4898ff4f1797c54b87d444206L19-R32) [[8]](diffhunk://#diff-8756049a55982116ad8e389b22df4cd8609af1f4898ff4f1797c54b87d444206L65-R81) [[9]](diffhunk://#diff-8756049a55982116ad8e389b22df4cd8609af1f4898ff4f1797c54b87d444206R95-R114) [[10]](diffhunk://#diff-8756049a55982116ad8e389b22df4cd8609af1f4898ff4f1797c54b87d444206L115-R158) [[11]](diffhunk://#diff-8756049a55982116ad8e389b22df4cd8609af1f4898ff4f1797c54b87d444206L200-R253)
* Updated translation and description strings to document the new temperature range options and their recommended values for safety. [[1]](diffhunk://#diff-c9804970f19bb1a00bc5a98b395440c01d228aac05fdf7ee96d7791239725b84L142-R151) [[2]](diffhunk://#diff-bd30003034edaaa178bbe52c24d67c1ef8b58a8d1532d721d4b1b3d7d077f4bfL141-R150)

**Service validation improvements:**

* Improved the `start_recirculation` service schema to coerce string inputs (from UI selectors) to integers before validation, fixing a bug where valid string values were previously rejected. Fixes #162 

**Testing enhancements:**

* Added new end-to-end tests for the recirculation services, including tests for type coercion and validation of allowed values, ensuring robust handling of user inputs. [[1]](diffhunk://#diff-d3011d3e72b032605c50a133683e2a0575328045397793a881f19d9a7471f6e5R1-R11) [[2]](diffhunk://#diff-d3011d3e72b032605c50a133683e2a0575328045397793a881f19d9a7471f6e5R282-R413)

**Other updates:**

* Bumped the integration version to 2.3.0 to reflect these new features.