### PR TITLE
Fix casting sw_version as int instead of str

### DIFF
--- a/custom_components/rinnai/device.py
+++ b/custom_components/rinnai/device.py
@@ -594,10 +594,11 @@ class RinnaiDeviceDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     @property
     def firmware_version(self) -> str | None:
         """Return the firmware version for the device."""
-        return self._get_value(
+        firmware = self._get_value(
             ("data", "getDevice", "firmware"),
             "module_firmware_version",
         )
+        return None if firmware is None else str(firmware)
 
     @property
     def thing_name(self) -> str | None:


### PR DESCRIPTION
This is an alternative PR for #167. `_get_local()` can return `None` and so this will preserve that rather than casting it as `str()` as well.